### PR TITLE
Pin punycode to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "selenium-webdriver": "^4.0.0-alpha.1"
   },
   "resolutions": {
-		"punycode": "^1.4.1"
-	}
+    "punycode": "^1.4.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "selenium-webdriver": "^4.0.0-alpha.1"
   },
   "resolutions": {
+    "//": "punycode v2 does not support browser clients",
     "punycode": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
     "@types/selenium-webdriver": "^4.0.0",
     "@4c/fetch-mock": "^8.0.0",
     "selenium-webdriver": "^4.0.0-alpha.1"
-  }
+  },
+  "resolutions": {
+		"punycode": "^1.4.1"
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6195,10 +6195,10 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+punycode@^1.4.1, punycode@^2.1.0, punycode@^2.1.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Here's where the issue I was seeing is -- punycode was covered by Webpack 4 using punycode *v1*, when that's removed we have to either fix the issue at the importer, or at each consumer.

It's really annoying but the maintainers of the punycode package created v2 _without_ browser support, so it totally breaks everything if you assume you can just upgrade

I think this is technically better done within fetch-mock, but it's using npm rather than yarn, and resolutions still haven't reached url: https://github.com/npm/rfcs/pull/129. Options are to use an npm-force-resolution package, or to switch to yarn, and I'm not sure we want that much movement for this

also note I'm not sure if this is the convention for polyfills -- normally it seems like it's up to the consumer, but this is a nuance that I don't think falls under standard polyfill requirements. Plus, it's our library, presumably we're intending to go to Webpack 5 on all consumers, and this hides that nuance from consumers